### PR TITLE
logformat: fix extra space in RFC5424 syslog header

### DIFF
--- a/lua/log/logformat/syslog.lua
+++ b/lua/log/logformat/syslog.lua
@@ -125,7 +125,7 @@ function M.new(facility, host_name, app_name, procid, msgid)
     return 
     -- HEADER
       -- PRI VERSION TIMESTAMP
-      '<' .. slvl + facility .. '> 1 ' .. Date2SysLog(now) .. ' ' ..
+      '<' .. slvl + facility .. '>1 ' .. Date2SysLog(now) .. ' ' ..
       -- HEADER STRUCTURED-DATA MSG
       header .. ' - ' ..  msg
     


### PR DESCRIPTION
This PR fixes a bug in syslog formatter where an extra space is sent in header preventing syslog parsers (tested with rsyslog) to properly decode messages as RFC5424.

From [RFC5424, Syslog Message Format](https://tools.ietf.org/html/rfc5424#section-6) :
```
HEADER          = PRI VERSION SP TIMESTAMP SP HOSTNAME
                        SP APP-NAME SP PROCID SP MSGID
```
There is no `SP` betwween `PRI` & `VERSION`.