### PR TITLE
properly honor flush_interval

### DIFF
--- a/lua/log/writer/file/private/impl.lua
+++ b/lua/log/writer/file/private/impl.lua
@@ -167,7 +167,7 @@ local function make_no_close_reset(flush_interval)
       writer = function (msg)
         f:write(msg, END_OF_LINE)
         counter = counter + 1
-        if counter > flush_interval then
+        if counter >= flush_interval then
           f:flush()
           counter = 0
         end


### PR DESCRIPTION
There was an off-by-one in the flush_interval handling - setting flush_interval to e.g. 1 would cause only every other line to be flushed. This fixes that.

I noticed this while using `log.writer.file.roll`, as there appeared to be a roughly 50% chance of a line not appearing in the log file until another line was logged.