### PR TITLE
logformat/syslog: use math.fmod instead of math.mod

### DIFF
--- a/lua/log/logformat/syslog.lua
+++ b/lua/log/logformat/syslog.lua
@@ -2,7 +2,7 @@ local string = require "string"
 local math   = require "math"
 local Log    = require "log"
 
-local mod,floor,ceil,abs,pow = math.mod,math.floor,math.ceil,math.abs,math.pow
+local mod,floor,ceil,abs,pow = math.fmod,math.floor,math.ceil,math.abs,math.pow
 local fmt = string.format
 
 -- removes the decimal part of a number


### PR DESCRIPTION
This PR will replace reference to deprecated math.mod function with math.fmod.

The math.mod function was deprecated in favor of a new math.fmod function in Lua 5.1. It was then removed in Lua 5.2. The [rockspec](https://github.com/moteus/lua-log/blob/master/rockspecs/lua-log-scm-0.rockspec#L17) file already requires at least Lua version 5.1, so this change should not cause any compatibility issues.